### PR TITLE
Find displayId by unitNumber and apply changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 /WindowServerConfig.xcodeproj/project.xcworkspace/xcuserdata/
 /build/
+
+*.xccheckout

--- a/WindowServerConfig.xcodeproj/project.pbxproj
+++ b/WindowServerConfig.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		3C72376518DBC80000ED73D9 /* WindowServerConfig */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WindowServerConfig; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C72376518DBC80000ED73D9 /* displaycfg */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = displaycfg; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C72376818DBC80000ED73D9 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		3C72376A18DBC80000ED73D9 /* WindowServerConfig.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = WindowServerConfig.1; sourceTree = "<group>"; };
 		3C72377618DBC8ED00ED73D9 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
@@ -74,7 +74,7 @@
 		3C72376618DBC80000ED73D9 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				3C72376518DBC80000ED73D9 /* WindowServerConfig */,
+				3C72376518DBC80000ED73D9 /* displaycfg */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -122,7 +122,7 @@
 			);
 			name = displaycfg;
 			productName = WindowServerConfig;
-			productReference = 3C72376518DBC80000ED73D9 /* WindowServerConfig */;
+			productReference = 3C72376518DBC80000ED73D9 /* displaycfg */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */

--- a/WindowServerConfig.xcodeproj/project.xcworkspace/xcshareddata/WindowServerConfig.xccheckout
+++ b/WindowServerConfig.xcodeproj/project.xcworkspace/xcshareddata/WindowServerConfig.xccheckout
@@ -12,22 +12,34 @@
 	<dict>
 		<key>19CFB676-3D32-496C-8C08-0C8D024C102B</key>
 		<string>ssh://github.com/calebjohnston/window-server-config.git</string>
+		<key>B46F4ABEA5E49A60919710D68BBDB12FCA11690C</key>
+		<string>https://github.com/jihyunlee/window-server-config.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>WindowServerConfig.xcodeproj/project.xcworkspace</string>
+	<string>WindowServerConfig.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>19CFB676-3D32-496C-8C08-0C8D024C102B</key>
+		<string>../../../WindowServerConfig</string>
+		<key>B46F4ABEA5E49A60919710D68BBDB12FCA11690C</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/calebjohnston/window-server-config.git</string>
+	<string>https://github.com/jihyunlee/window-server-config.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>19CFB676-3D32-496C-8C08-0C8D024C102B</string>
+	<string>B46F4ABEA5E49A60919710D68BBDB12FCA11690C</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>B46F4ABEA5E49A60919710D68BBDB12FCA11690C</string>
+			<key>IDESourceControlWCCName</key>
+			<string>window-server-config</string>
+		</dict>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>

--- a/WindowServerConfig/DisplayLayout.h
+++ b/WindowServerConfig/DisplayLayout.h
@@ -30,6 +30,7 @@ public:
 	typedef struct frame_t {
         uint32_t displayID;
         uint32_t serialNumber;
+		uint32_t unitNumber;
 		uint32_t position_x;
 		uint32_t position_y;
 		uint32_t width;
@@ -95,9 +96,6 @@ public:
 	//! Accessor method to enable or disable the permanent or temporary status of the changes
 	void setPersistence(const Persistence setting) { mPersistence = setting; }
 	Persistence persistence() const { return mPersistence; }
-	
-	//! Takes the input data and executes the configuration change
-	bool applyLayoutChanges();
 	
     bool applyChanges(std::vector<Frame> &display_frames);
 

--- a/WindowServerConfig/DisplayLayout.h
+++ b/WindowServerConfig/DisplayLayout.h
@@ -29,6 +29,7 @@ class DisplayLayout {
 public:
 	typedef struct frame_t {
         uint32_t displayID;
+        uint32_t serialNumber;
 		uint32_t position_x;
 		uint32_t position_y;
 		uint32_t width;
@@ -94,7 +95,7 @@ public:
 	//! Takes the input data and executes the configuration change
 	bool applyLayoutChanges();
 	
-    bool applyChanges(std::vector<DisplayLayout::Frame> &display_frames);
+    bool applyChanges(std::vector<Frame> &display_frames);
 
         
 private:

--- a/WindowServerConfig/DisplayLayout.h
+++ b/WindowServerConfig/DisplayLayout.h
@@ -67,6 +67,10 @@ public:
 	uint32_t desiredResolutionWidth() const { return mResWidth; }
 	uint32_t desiredResolutionHeight() const { return mResHeight; }
 	
+    //! Accessor method for the desired frequency
+    void setDesiredFrequency(const uint32_t freq) { mFreq = freq; }
+    uint32_t desiredFrequency() const { return mFreq; }
+    
 	//! Accessor method for the desired number of columns in a display wall
 	void setDesiredColumns(const uint8_t width) { mColumns = width; }
 	uint8_t desiredColumns() const { return mColumns; }
@@ -102,6 +106,7 @@ private:
     
 	uint32_t mResWidth;
 	uint32_t mResHeight;
+    uint32_t mFreq;
 	uint8_t mColumns;
 	uint8_t mRows;
 	std::unordered_map<uint32_t, Frame> mDeviceFrames;

--- a/WindowServerConfig/main.cpp
+++ b/WindowServerConfig/main.cpp
@@ -155,7 +155,7 @@ int main(int argc, const char * argv[])
                 std::vector<uint32_t> display_ids;
                 for(std::vector<int32_t>::iterator iter = display_data.begin(); iter != display_data.end(); ++iter) {
                     DisplayLayout::Frame* frame = new DisplayLayout::Frame();
-                    frame->displayID = *iter++;
+                    frame->serialNumber = *iter++;
                     frame->position_x = *iter++;
                     frame->position_y = *iter++;
                     frame->width = *iter++;

--- a/WindowServerConfig/main.cpp
+++ b/WindowServerConfig/main.cpp
@@ -159,7 +159,9 @@ int main(int argc, const char * argv[])
                 std::vector<uint32_t> display_ids;
                 for(std::vector<int32_t>::iterator iter = display_data.begin(); iter != display_data.end(); ++iter) {
                     DisplayLayout::Frame* frame = new DisplayLayout::Frame();
-                    frame->serialNumber = *iter++;
+//					frame->displayID = *iter++;
+//					frame->serialNumber = *iter++;
+					frame->unitNumber = *iter++;
                     frame->position_x = *iter++;
                     frame->position_y = *iter++;
                     frame->width = *iter++;

--- a/WindowServerConfig/main.cpp
+++ b/WindowServerConfig/main.cpp
@@ -147,6 +147,10 @@ int main(int argc, const char * argv[])
 				display_layout.setDesiredResolution(resolution.at(0), resolution.at(1));
 			}
             
+            // set display frequency
+            if (var_map.count("refresh")) {
+                display_layout.setDesiredFrequency(refresh_rate);
+            }
             
             // --display position and resolution with display ID
             std::vector<DisplayLayout::Frame> display_frames;


### PR DESCRIPTION
Since displayId and serial number are not consistent, use unitNumber to find displayId and then apply changes accordingly.
